### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
 	},
 	"author": "Alan <alanscodelog@gmail.com>",
 	"repository": "github:alanscodelog/commitlint-config",
+	"homepage": "https://github.com/alanscodelog/commitlint-config#readme",
+	"bugs": {
+		"url": "https://github.com/alanscodelog/commitlint-config/issues"
+	},
 	"license": "MIT",
 	"files": [
 		"commitlint.config.js"


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to the repository README
- add `bugs.url` metadata pointing to the GitHub issue tracker
- leave runtime code, dependencies, and package contents unchanged

## Validation
- `node` package metadata assertion
- `npm view @alanscodelog/commitlint-config@3.1.3 name version repository homepage bugs --json`
- `HUSKY=0 npm pack --dry-run --json .`
- `pnpm lint:commits`
- `git diff --check`

Note: `npm ci --ignore-scripts` was not usable because the existing `package-lock.json` is out of sync with `package.json`; `pnpm install --ignore-scripts` succeeded with the current `pnpm-lock.yaml`.